### PR TITLE
Prevent opening diff tool if MD5 matches

### DIFF
--- a/lib/Logger.coffee
+++ b/lib/Logger.coffee
@@ -36,6 +36,9 @@ class Logger
 
     msg
 
+  ok: (message, icon) ->
+	atom.notifications.addSuccess msg, {icon}
+
   log: (message) ->
     date = new Date
     startTime = date.getTime()

--- a/lib/RemoteSync.coffee
+++ b/lib/RemoteSync.coffee
@@ -293,6 +293,9 @@ class RemoteSync
   diff: (localPath, targetPath) ->
     return if @isIgnore(localPath)
     targetPath = path.join(targetPath, path.relative(@projectPath, localPath))
+    if fs.md5ForPath(localPath) == fs.md5ForPath(targetPath)
+      getLogger().ok "Files are synced" "diff"
+      return
     diffCmd = atom.config.get('remote-sync-pro.difftoolCommand')
     exec ?= require("child_process").exec
     exec "\"#{diffCmd}\" \"#{localPath}\" \"#{targetPath}\"", (err)->


### PR DESCRIPTION
When you compare local and remote files and they're equal, you must manually close the diff tool.
Instead, compare local/remote MD5 and inform user if they're synced, without uselessly opening another app 